### PR TITLE
fix-babel - Added babel parameter to ignore test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validate": "npx tsc -noEmit --skipLibCheck",
     "start": "node dist/app/server.js",
     "lint": "eslint --fix",
-    "build": "babel src --extensions \".js,.ts\" --out-dir dist --copy-files --no-copy-ignored",
+    "build": "babel src --extensions \".js,.ts\" --out-dir dist --copy-files --no-copy-ignored --ignore '**/*.test.js'",
     "dev": "ts-node-dev -r --respawn --transpile-only --ignore-watch node_modules --no-notify src/app/server.ts"
   },
   "author": "",


### PR DESCRIPTION
# Contexto

A pasta dist estava contendo os arquivos de teste sem necessidade.

## Como testar

Basta executar o build e validar que na pasta dist os arquivos .test.ts não estarão presentes.
