### PR TITLE
fix: adjust find by id order

### DIFF
--- a/src/adapters/gateways/database/order/queries/find-by-id.ts
+++ b/src/adapters/gateways/database/order/queries/find-by-id.ts
@@ -1,13 +1,13 @@
 export const FIND_BY_ID = `SELECT 
             o.*,
-            json_build_object(
+            json_agg(json_build_object(
                 'id', c.id,
                 'name', c.name,
                 'document_number', c.document_number,
                 'email', c.email,
                 'created_at', c.created_at,
                 'updated_at', c.updated_at
-            ) AS customer,
+            )) AS customer,
             json_agg(json_build_object(
                 'id', p.id,
                 'name', p.name,
@@ -23,4 +23,5 @@ export const FIND_BY_ID = `SELECT
           LEFT JOIN public.customers c ON o.customer_id = c.id
           JOIN public.orders_products op ON o.id = op.order_id
           JOIN public.products p ON op.product_id = p.id
-          WHERE o.id = :id`;
+          WHERE o.id = :id
+          GROUP BY o.id`;


### PR DESCRIPTION
# Contexto

O objetivo da alteração é ajustar a query de obtenção de pedidos por id, para evitar o erro: "column \"o.id\" must appear in the GROUP BY clause or be used in an aggregate function"

## Como testar

Para testar é necessário executar o endpoint de update de status do pedido, e também o get de pedidos.
